### PR TITLE
Fix version error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.43.1
-constructs==10.1.111
-cdk-nag==2.18.15
+aws-cdk-lib==2.143.1
+constructs==10.3.0
+cdk-nag==2.28.129

--- a/src/amplify_add_on_stack.py
+++ b/src/amplify_add_on_stack.py
@@ -74,7 +74,7 @@ class CustomAmplifyDistributionStack(Stack):
             self,
             "rAmplifyCredentialsRetrievalFunction",
             description="custom function to retrieve value of scecrets that contain amplify auth info",  # noqa 501
-            runtime=Runtime.PYTHON_3_9,
+            runtime=Runtime.PYTHON_3_12,
             handler="lambda_function.lambda_handler",
             code=Code.from_asset(
                 path=os.path.join(dirname, "functions/password_retrieval")
@@ -207,7 +207,7 @@ class CustomAmplifyDistributionStack(Stack):
             self,
             "rCacheInvalidationFunction",
             description="custom function to trigger cloudfront cache invalidation",  # noqa 501
-            runtime=Runtime.PYTHON_3_9,
+            runtime=Runtime.PYTHON_3_12,
             handler="lambda_function.lambda_handler",
             code=Code.from_asset(
                 path=os.path.join(dirname, "functions/cache_invalidation")


### PR DESCRIPTION
*Issue #8 , if available:*

*Description of changes:*

- Upgrade aws-cdk, constructs, cdk-nag to support nodejs 14.x end-of-support
   - issue #8 
- cdk-nag only allows the latest version, so change Python runtime 3.9 ->3.12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
